### PR TITLE
field error message with error (red) color

### DIFF
--- a/src/Input.tsx
+++ b/src/Input.tsx
@@ -19,7 +19,7 @@ const InputWrapper: React.SFC<FieldRenderProps> = ({input: {name, onChange, valu
 			/>
 
 			{showError &&
-				<FormHelperText>
+				<FormHelperText error>
 					{meta.error || meta.submitError}
 				</FormHelperText>
 			}


### PR DESCRIPTION
If the <Input component has error state, it was not displayed in red.